### PR TITLE
Remove superfluous headers from 30x responses

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -29,24 +29,24 @@ http {
             stub_status;
         }
 
-        # 30min cache
-        add_header Cache-Control "public, max-age=1800";
-
-        # More headers
-        add_header Strict-Transport-Security "max-age=31536000";
-        add_header X-Content-Type-Options "nosniff";
-        add_header X-Frame-Options "DENY";
-        add_header X-XSS-Protection "1; mode=block";
-        add_header X-Clacks-Overhead "GNU Terry Pratchett";
-        add_header Content-Security-Policy "default-src 'self'; object-src 'none'";
-
         location / {
             try_files $uri $uri/index.html $uri.html @redirects;
             root   /app/content;
             index  index.html index.htm;
+
+            add_header Cache-Control "public, max-age=1800";
+            add_header Strict-Transport-Security "max-age=31536000";
+            add_header X-Clacks-Overhead "GNU Terry Pratchett";
+            add_header X-Content-Type-Options "nosniff";
+            add_header X-Frame-Options "DENY";
+            add_header X-XSS-Protection "1; mode=block";
+            add_header Content-Security-Policy "default-src 'self'; object-src 'none'";
         }
 
         location @redirects {
+            add_header Cache-Control "public, max-age=1800";
+            add_header Strict-Transport-Security "max-age=31536000";
+            add_header X-Clacks-Overhead "GNU Terry Pratchett";
             # bug 870410
             #RewriteRule ^/universityambassadors$ https://www.mozilla.org/contribute/universityambassadors/?redirect_source=firefox-com [NC,R=302,QSA]
             # original redirect target is now a redirect to the below

--- a/tests/tests/test_redirects.py
+++ b/tests/tests/test_redirects.py
@@ -115,6 +115,8 @@ def assert_redirect(base_url, url, location, code=302):
     resp = requests.get(f"{base_url}{url}", allow_redirects=False)
     assert resp.status_code == code
     assert resp.headers["location"] == location
+    assert resp.headers["Strict-Transport-Security"] == "max-age=31536000"
+    assert resp.headers["Cache-Control"] == "public, max-age=1800"
 
 
 @pytest.mark.parametrize("args", URLS, ids=itemgetter(0))
@@ -122,7 +124,7 @@ def test_redirect(args, base_url):
     assert_redirect(base_url, *args)
 
 
-@pytest.mark.parametrize("path", ["/", "/healthz/"])
+@pytest.mark.parametrize("path", ["/healthz/"])
 def test_security_headers(path, base_url):
     resp = requests.get(f"{base_url}{path}", allow_redirects=False)
     for header, value in HEADERS:


### PR DESCRIPTION
Extra headers are being sent with 30x responses that don't do anything for that kind of response. I've tweaked the config to send appropriate headers for both HTML and redirect responses.