### PR TITLE
Update campaign redirect default UTM params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ pull: stop
 push:
 	${DC} push web test
 
-test: stop
+test: build
 	${DC} run test
 	${DC} down
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,6 +25,10 @@ http {
         server_name localhost;
         charset "utf-8";
 
+        add_header Cache-Control "public, max-age=1800";
+        add_header Strict-Transport-Security "max-age=31536000";
+        add_header X-Clacks-Overhead "GNU Terry Pratchett";
+
         location /stub_status {
             stub_status;
         }
@@ -44,9 +48,6 @@ http {
         }
 
         location @redirects {
-            add_header Cache-Control "public, max-age=1800";
-            add_header Strict-Transport-Security "max-age=31536000";
-            add_header X-Clacks-Overhead "GNU Terry Pratchett";
             # bug 870410
             #RewriteRule ^/universityambassadors$ https://www.mozilla.org/contribute/universityambassadors/?redirect_source=firefox-com [NC,R=302,QSA]
             # original redirect target is now a redirect to the below
@@ -111,13 +112,6 @@ http {
             # https://github.com/mozmeao/www.firefox.com/issues/9
             rewrite (?i)^/nightly/?$ https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly permanent;
 
-            # https://github.com/mozmeao/www.firefox.com/issues/13 and Jira SE-1256
-            rewrite (?i)^/unfu?ck/?$ https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com permanent;
-            # https://github.com/mozmeao/www.firefox.com/issues/15
-            rewrite (?i)^/love/?$ https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com permanent;
-            # https://github.com/mozmeao/www.firefox.com/issues/18
-            rewrite (?i)^/liebe/?$ https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com permanent;
-
             # issue #21
             rewrite (?i)^/armchair/?$ https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_medium=audio&utm_source=armchair&utm_campaign=unfck&utm_content=podcast permanent;
             rewrite (?i)^/jvn/?$ https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_medium=audio&utm_source=jvn&utm_campaign=unfck&utm_content=podcast permanent;
@@ -134,6 +128,14 @@ http {
             # bug 1427843
             #RewriteRule ^/ https://www.mozilla.org/firefox/new/?redirect_source=firefox-com [NC,R=301,QSA]
             rewrite ^/ https://www.mozilla.org/firefox/new/?redirect_source=firefox-com;
+        }
+
+        # issues #19, #18, #15, and #13, and Jira SE-1256
+        location ~* /(unfu?ck|love|liebe) {
+            if ($args ~* utm_) {
+                return 301 https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&$args;
+            }
+            return 301 https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_medium=referral&utm_source=firefox.com&utm_campaign=unfck;
         }
     }
 }

--- a/tests/tests/test_redirects.py
+++ b/tests/tests/test_redirects.py
@@ -78,16 +78,26 @@ URLS = (
     ("/privatsphaere/", "https://www.mozilla.org/firefox/privacy/products/?redirect_source=firefox-com"),
     ("/vieprivee/", "https://www.mozilla.org/firefox/privacy/products/?redirect_source=firefox-com"),
     ("/vieprivée/", "https://www.mozilla.org/firefox/privacy/products/?redirect_source=firefox-com"),
-    ("/unfck/", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com", 301),
+    ("/unfck/", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&"
+                "utm_medium=referral&utm_source=firefox.com&utm_campaign=unfck", 301),
     (
-        # any incoming query params should combine with the one in the config
+        # any incoming utm params should replace the default ones
         "/unfck/?utm_campaign=social",
         "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_campaign=social",
         301
     ),
-    ("/unfuck/", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com", 301),
-    ("/love/", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com", 301),
-    ("/liebe/", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com", 301),
+    (
+        # any incoming utm params should replace the default ones
+        "/love?utm_source=twitter&utm_medium=aether",
+        "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_source=twitter&utm_medium=aether",
+        301
+    ),
+    ("/unfuck", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&"
+                "utm_medium=referral&utm_source=firefox.com&utm_campaign=unfck", 301),
+    ("/love", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&"
+              "utm_medium=referral&utm_source=firefox.com&utm_campaign=unfck", 301),
+    ("/liebe", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&"
+               "utm_medium=referral&utm_source=firefox.com&utm_campaign=unfck", 301),
     ("/armchair", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&"
                   "utm_medium=audio&utm_source=armchair&utm_campaign=unfck&utm_content=podcast", 301),
     ("/jvn", "https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&"


### PR DESCRIPTION
Also make sure that the default UTMs are only added if no UTMs exist on
the incoming URI.

Fix #19
