### PR TITLE
eks change

### DIFF
--- a/k8s/deploy.yml
+++ b/k8s/deploy.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Different versions of k8s have different extension names.  1.16 shift.  Kops clusters are 1.13 and eks is 1.19, so we're leaping through the big naming shift.